### PR TITLE
Modernize vsphere-vm module (runner, provider, workflows, docs)

### DIFF
--- a/.github/workflows/pages.yaml
+++ b/.github/workflows/pages.yaml
@@ -1,0 +1,16 @@
+---
+name: Deploy Pages
+on:
+  workflow_dispatch:
+  workflow_run:
+    workflows: ["Validate and Release Terraform Module"]
+    types: [completed]
+
+jobs:
+  pages:
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      github.event.workflow_run.conclusion == 'success'
+    uses: stuttgart-things/github-workflow-templates/.github/workflows/call-deploy-pages.yaml@main
+    with:
+      runs-on: ubuntu-latest

--- a/.github/workflows/release-terraform.yaml
+++ b/.github/workflows/release-terraform.yaml
@@ -9,35 +9,28 @@ on:
       release-message:
         required: true
         type: string
-      github-runner:
-        required: false
-        type: string
-        default: ghr-vsphere-vm-cicd
-      environment-name:
-        required: false
-        type: string
-        default: k8s
-        
+
 jobs:
-  validate-terraform:
-    name: Valdiate
-    uses: stuttgart-things/stuttgart-things/.github/workflows/validate-terraform.yaml@main  
+  Validate-Terraform:
+    if: github.event.ref == 'refs/heads/main'
+    name: Validate
+    uses: stuttgart-things/github-workflow-templates/.github/workflows/call-validate-terraform.yaml@main
     with:
-      environment-name: "${{ github.event.inputs.environment-name }}"
-      runs-on: "${{ github.event.inputs.github-runner }}"
-      terraform-version: 1.7.5
-      tflint-version: v0.50.3
+      environment-name: k8s
+      runs-on: ghr-vsphere-vm-in-cluster
+      terraform-version: 1.10.5
+      tflint-version: v0.55.1
       continue-error: false
 
-  release-terraform:
+  Release-Terraform:
+    if: github.event.ref == 'refs/heads/main'
     name: Release
-    needs: validate-terraform
-    uses: stuttgart-things/stuttgart-things/.github/workflows/call-release-module.yaml@main  
+    needs: Validate-Terraform
+    uses: stuttgart-things/github-workflow-templates/.github/workflows/call-release-module.yaml@main
     with:
       module-name: vsphere-vm
-      archive-kind: zip
       tag-name: "${{ github.event.inputs.release-tag }}"
       release-message: "${{ github.event.inputs.release-message }}"
-      environment-name: "${{ github.event.inputs.environment-name }}"
-      runs-on: "${{ github.event.inputs.github-runner }}"
+      environment-name: k8s
+      runs-on: ghr-vsphere-vm-in-cluster
       continue-error: false

--- a/.github/workflows/validate-terraform.yaml
+++ b/.github/workflows/validate-terraform.yaml
@@ -1,21 +1,40 @@
 ---
-name: Validate Terraform
+name: Terraform
 on:
+  workflow_dispatch:
   push:
     branches:
-      - main
-      - feature/*
-      - fix/*
+      - 'feature/**'
+      - 'feat/**'
+      - 'fix/**'
+      - 'renovate/**'
   pull_request:
     types: [opened, reopened]
 
 jobs:
   validate-terraform:
-    name: Valdiate
-    uses: stuttgart-things/stuttgart-things/.github/workflows/validate-terraform.yaml@main  
+    name: Validate
+    uses: stuttgart-things/github-workflow-templates/.github/workflows/call-validate-terraform.yaml@main
     with:
       environment-name: k8s
-      runs-on: ghr-vsphere-vm-cicd
-      terraform-version: 1.7.5
-      tflint-version: v0.50.3
+      runs-on: ghr-vsphere-vm-in-cluster
+      terraform-version: 1.10.5
+      tflint-version: v0.55.1
+      continue-error: false
+
+  terraform-docs:
+    name: Docs
+    uses: stuttgart-things/github-workflow-templates/.github/workflows/call-terraform-docs.yaml@main
+    with:
+      environment-name: k8s
+      runs-on: ghr-vsphere-vm-in-cluster
+      continue-error: false
+
+  terraform-security:
+    name: Security
+    uses: stuttgart-things/github-workflow-templates/.github/workflows/call-terraform-security.yaml@main
+    with:
+      environment-name: k8s
+      runs-on: ghr-vsphere-vm-in-cluster
+      severity: HIGH,CRITICAL
       continue-error: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,34 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-added-large-files
+      - id: check-merge-conflict
+      - id: check-symlinks
+      - id: check-yaml
+        args: ['--allow-multiple-documents']
+      - id: detect-private-key
+  - repo: https://github.com/jumanjihouse/pre-commit-hooks
+    rev: 3.0.0
+    hooks:
+      - id: shellcheck
+        args:
+          - "-e"
+          - "SC1090"
+          - "-e"
+          - "SC1091"
+  - repo: https://github.com/sirosen/check-jsonschema
+    rev: 0.30.0
+    hooks:
+      - id: check-github-workflows
+  - repo: https://github.com/Yelp/detect-secrets
+    rev: v1.5.0
+    hooks:
+      - id: detect-secrets
+        name: Detect secrets
+        description: Detects high entropy strings that are likely to be passwords.
+        entry: detect-secrets-hook
+        language: python
+        files: .*

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,27 @@
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: vsphere-vm
+  description: Terraform module for creating vSphere virtual machines
+  annotations:
+    github.com/project-slug: stuttgart-things/vsphere-vm
+    backstage.io/techdocs-ref: url:https://github.com/stuttgart-things/vsphere-vm/tree/main
+    backstage.io/source-location: url:https://github.com/stuttgart-things/vsphere-vm
+  tags:
+    - terraform
+    - vsphere
+    - infrastructure
+    - vm
+  links:
+    - url: https://github.com/stuttgart-things/vsphere-vm
+      title: GitHub Repository
+      icon: github
+    - url: https://registry.terraform.io/providers/hashicorp/vsphere/latest/docs
+      title: Provider Documentation
+      icon: docs
+spec:
+  type: library
+  lifecycle: production
+  owner: platform-team
+  system: platform-engineering

--- a/docs/CICD.md
+++ b/docs/CICD.md
@@ -1,0 +1,56 @@
+# CI/CD
+
+## Pipeline Overview
+
+```
+Push / PR
+  │
+  ├── Validate ─── terraform validate
+  │
+  ├── Docs ─────── terraform-docs
+  │
+  └── Security ─── tfsec (HIGH, CRITICAL)
+```
+
+## Workflows
+
+| Workflow | Trigger | Description |
+|----------|---------|-------------|
+| `validate-terraform.yaml` | push to feature/fix/renovate branches, PRs | Validate, docs, and security checks |
+| `release-terraform.yaml` | manual dispatch | Validate and create GitHub release |
+| `pages.yaml` | manual dispatch or release completion | Deploy MkDocs to GitHub Pages |
+
+All jobs use reusable workflows from [stuttgart-things/github-workflow-templates](https://github.com/stuttgart-things/github-workflow-templates).
+
+## Validation Jobs
+
+| Job | Tool | Version | Description |
+|-----|------|---------|-------------|
+| Terraform-Validate | terraform | 1.10.5 | `terraform init` + `terraform validate` |
+| Terraform-Docs | terraform-docs | - | Generate and verify documentation |
+| Terraform-Security | tfsec | - | Scan for HIGH and CRITICAL severity issues |
+
+## Release Process
+
+Releases are triggered manually via `workflow_dispatch` with:
+
+- `release-tag` — semantic version tag (e.g. `v2.12.0`)
+- `release-message` — release description
+
+The release workflow validates first, then creates a GitHub release with the module archive.
+
+## Pre-commit Hooks
+
+Local checks configured in `.pre-commit-config.yaml`:
+
+| Hook | Purpose |
+|------|---------|
+| `trailing-whitespace` | Remove trailing whitespace |
+| `end-of-file-fixer` | Ensure files end with newline |
+| `check-added-large-files` | Prevent large file commits |
+| `check-merge-conflict` | Detect merge conflict markers |
+| `check-yaml` | Validate YAML syntax |
+| `detect-private-key` | Detect accidentally committed keys |
+| `detect-secrets` | High-entropy password detection |
+| `shellcheck` | Shell script linting |
+| `check-github-workflows` | Validate GitHub Actions schema |

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,54 @@
+# vSphere VM
+
+Terraform module for creating vSphere virtual machines based on the [hashicorp/vsphere](https://registry.terraform.io/providers/hashicorp/vsphere/latest) provider (v2.12.0).
+
+## Overview
+
+This module provisions VMs on VMware vSphere by cloning templates. It supports:
+
+- Multi-VM creation (1-5 VMs per invocation)
+- CPU, memory, disk, and network customization
+- Firmware selection (BIOS or EFI)
+- Automatic hostname provisioning via SSH
+- Bootstrap command execution on first boot
+
+## Quick Start
+
+```hcl
+module "vsphere-vm" {
+  source                 = "git::https://github.com/stuttgart-things/vsphere-vm.git"
+  vsphere_vm_name        = "my-vm"
+  vm_count               = 1
+  vm_memory              = 4096
+  vm_num_cpus            = 4
+  vm_disk_size           = "32"
+  firmware               = "bios"
+  vsphere_vm_folder_path = "stuttgart-things/dev"
+  vsphere_datacenter     = "/MyDatacenter"
+  vsphere_datastore      = "/MyDatacenter/datastore/MyDatastore"
+  vsphere_resource_pool  = "Resources"
+  vsphere_network        = "/MyDatacenter/network/VM Network"
+  vsphere_vm_template    = "/MyDatacenter/vm/templates/ubuntu24"
+  vm_ssh_user            = var.vm_ssh_user
+  vm_ssh_password        = var.vm_ssh_password
+  bootstrap              = ["echo STUTTGART-THINGS"]
+  vsphere_user           = var.vsphere_user
+  vsphere_password       = var.vsphere_password
+  vsphere_server         = var.vsphere_server
+}
+```
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| `ip` | IPv4 addresses of created VMs |
+
+## Crossplane Integration
+
+This module can also be used with [Crossplane](https://crossplane.io/) via the Upbound Terraform Provider as a `Workspace` resource. See the [README](https://github.com/stuttgart-things/vsphere-vm#usage-crossplane) for a full example.
+
+## Related Documentation
+
+- [Variables Reference](variables.md)
+- [CI/CD](CICD.md)

--- a/docs/variables.md
+++ b/docs/variables.md
@@ -1,0 +1,55 @@
+# Variables Reference
+
+## vSphere API
+
+| Name | Type | Default | Description |
+|------|------|---------|-------------|
+| `vsphere_server` | string | - | vSphere server FQDN |
+| `vsphere_user` | string | - | vSphere API username |
+| `vsphere_password` | string | - | vSphere API password |
+| `unverified_ssl` | bool | `true` | Allow unverified SSL connections |
+
+## Infrastructure
+
+| Name | Type | Default | Description |
+|------|------|---------|-------------|
+| `vsphere_datacenter` | string | - | vSphere datacenter name |
+| `vsphere_datastore` | string | - | vSphere datastore path |
+| `vsphere_resource_pool` | string | - | Resource pool name |
+| `vsphere_network` | string | - | Network path |
+| `vsphere_vm_template` | string | - | VM template to clone from |
+| `vsphere_vm_folder_path` | string | `/` | Target VM folder path |
+
+## VM Configuration
+
+| Name | Type | Default | Validation | Description |
+|------|------|---------|------------|-------------|
+| `vsphere_vm_name` | string | `terraform-vm` | starts with letter, 1-32 chars | Base name for VMs |
+| `vm_count` | number | `1` | 1-5 | Number of VMs to create |
+| `annotation` | string | `====STUTTGART-THINGS/VM====` | - | VM notes in vCenter |
+| `firmware` | string | `bios` | - | Firmware type (bios or EFI) |
+
+## Compute
+
+| Name | Type | Default | Validation | Description |
+|------|------|---------|------------|-------------|
+| `vm_num_cpus` | number | `4` | 2,4,6,8,10,12,16 | CPU cores |
+| `vm_memory` | number | `4096` | 1024,2048,4096,6144,8192,12288,16384,20480,24576 | Memory in MB |
+
+## Storage
+
+| Name | Type | Default | Validation | Description |
+|------|------|---------|------------|-------------|
+| `vm_disk_size` | string | `"32"` | 20,32,64,96,128,196,256 | Disk size in GB |
+| `vm_disk_label` | string | `"disk0"` | - | Disk label |
+
+## SSH Provisioner
+
+| Name | Type | Default | Description |
+|------|------|---------|-------------|
+| `vm_ssh_user` | string | - | SSH username for post-clone provisioning |
+| `vm_ssh_password` | string | - | SSH password for post-clone provisioning |
+| `ssh_agent` | bool | `false` | Use ssh-agent for authentication |
+| `bootstrap` | list(string) | `["whoami", "hostname"]` | Commands to run after VM creation |
+
+The SSH provisioner sets the hostname and regenerates the machine-id after cloning.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,10 @@
+site_name: vSphere VM
+site_description: Terraform module for creating vSphere virtual machines
+
+nav:
+  - Home: index.md
+  - Variables: variables.md
+  - CI/CD: CICD.md
+
+plugins:
+  - techdocs-core

--- a/provider.tf
+++ b/provider.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = ">= 1.7.5"
+  required_version = ">= 1.5.5"
 
   required_providers {
     vsphere = {
       source  = "hashicorp/vsphere"
-      version = ">= 2.7.0"
+      version = "2.12.0"
     }
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -62,6 +62,12 @@ variable "vm_memory" {
   default     = 4096
   type        = number
   description = "amount of memory of the vm"
+
+  validation {
+    condition     = contains([1024, 2048, 4096, 6144, 8192, 12288, 16384, 20480, 24576], var.vm_memory)
+    error_message = "Valid values for vm_memory are (1024, 2048, 4096, 6144, 8192, 12288, 16384, 20480, 24576)"
+  }
+
 }
 
 variable "vm_num_cpus" {


### PR DESCRIPTION
## Summary

Brings vsphere-vm in line with the proxmox-vm module patterns:

- **Runner**: `ghr-vsphere-vm-cicd` → `ghr-vsphere-vm-in-cluster`
- **Provider**: `>= 2.7.0` → `2.12.0` (latest stable), Terraform `>= 1.5.5`
- **Workflows**: Fixed "Valdiate" typo, migrated to `github-workflow-templates`, added terraform-docs + terraform-security jobs, added `pages.yaml` for MkDocs deployment
- **Tooling**: Terraform `1.10.5`, tflint `v0.55.1` in CI
- **Validation**: Added `vm_memory` validation block (1024-24576 MB)
- **Docs**: Added `mkdocs.yml`, `docs/index.md`, `docs/variables.md`, `docs/CICD.md`
- **Backstage**: Added `catalog-info.yaml` with techdocs-ref
- **Pre-commit**: Added `.pre-commit-config.yaml` with security and quality hooks

Closes #8 #9 #10 #11 #12

## Test plan

- [ ] Validate workflow triggers on push to feature branch
- [ ] terraform-docs and terraform-security jobs run successfully
- [ ] `terraform init && terraform validate` passes with provider 2.12.0
- [ ] MkDocs builds with techdocs-core plugin
- [ ] Pre-commit hooks pass locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)